### PR TITLE
Evita que quarto sobreescrigui les pàgines de pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,11 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  # Render and Publish corre en push i schedule
-  workflow_run:
-    workflows: [Render and Publish]
-    types:
-      - completed
   pull_request:
     branches: [main, master]
   release:
@@ -17,7 +12,6 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' }} || ${{ github.event.workflow_run.conclusion == 'success' }}
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ També es mostra quins conjunts de canvis han trencat les etiquetes amb enllaço
 
 Si voleu afegir objectes amb les seves etiquetes a les bases de dades, podeu obrir un
 [tiquet](https://github.com/OSM-Catalan/monitorOSM/issues) o podeu provar de fer un PR amb les instruccions que trobareu
-a [aquí](https://osm-catalan.github.io/monitorOSM/data-raw/README.html). Fora bo que els estats de referència
+a [aquí](https://osm-catalan.github.io/monitorOSM/web/data-raw/README.html). Fora bo que els estats de referència
 dels objectes siguin consensuats amb la 
 [Comunitat d'OpenStreetmap en català](https://wiki.openstreetmap.org/wiki/WikiProject_Catalan#Canals_de_comunicaci%C3%B3_i_mitjans_de_difusi%C3%B3).
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Si voleu afegir objectes amb les seves etiquetes a les bases de dades,
 podeu obrir un
 [tiquet](https://github.com/OSM-Catalan/monitorOSM/issues) o podeu
 provar de fer un PR amb les instruccions que trobareu a
-[aquí](https://osm-catalan.github.io/monitorOSM/data-raw/README.html).
+[aquí](https://osm-catalan.github.io/monitorOSM/web/data-raw/README.html).
 Fora bo que els estats de referència dels objectes siguin consensuats
 amb la [Comunitat d’OpenStreetmap en
 català](https://wiki.openstreetmap.org/wiki/WikiProject_Catalan#Canals_de_comunicaci%C3%B3_i_mitjans_de_difusi%C3%B3).

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,7 @@
 project:
   type: website
   execute-dir: project
+  output-dir: web
   render:
     - README.Rmd
     - data-raw/README.md


### PR DESCRIPTION
- Quarto renderitza a la carpeta "web" i pkgdown a "doc".
- Elimina l'activació de l'acció de pkgdown després de cada renderitzat de quarto
- Menys processament i menys CO2 pel planeta