### PR TITLE
Xixona és place=village

### DIFF
--- a/data-raw/loc_admin_centre_municipis.tsv
+++ b/data-raw/loc_admin_centre_municipis.tsv
@@ -1381,7 +1381,7 @@
 "PV"	"l'Alacantí"	"Mutxamel"	"node"	"276173656"	"Mutxamel"	"Mutxamel"	"Q1631458"	"ca:Mutxamel"	"town"	"8"	
 "PV"	"l'Alacantí"	"Sant Joan d'Alacant"	"node"	"276173625"	"Sant Joan d'Alacant"	"Sant Joan d'Alacant"	"Q740204"	"ca:Sant Joan d'Alacant"	"town"	"8"	
 "PV"	"l'Alacantí"	"Sant Vicent del Raspeig"	"node"	"3080250817"	"Sant Vicent del Raspeig"	"Sant Vicent del Raspeig / San Vicente del Raspeig"	"Q491667"	"ca:Sant Vicent del Raspeig"	"town"	"6"	
-"PV"	"l'Alacantí"	"Xixona"	"node"	"358084231"	"Xixona"	"Xixona / Jijona"	"Q747527"	"ca:Xixona"	"town"	"8"	
+"PV"	"l'Alacantí"	"Xixona"	"node"	"358084231"	"Xixona"	"Xixona / Jijona"	"Q747527"	"ca:Xixona"	"village"	"8"	
 "PV"	"l'Alcalatén"	"Costur"	"node"	"276699047"	"Costur"	"Costur"	"Q1645737"	"ca:Costur"	"village"	"8"	
 "PV"	"l'Alcalatén"	"Figueroles"	"node"	"290843784"	"Figueroles"	"Figueroles"	"Q1646916"	"ca:Figueroles"	"village"	"8"	
 "PV"	"l'Alcalatén"	"l'Alcora"	"node"	"1470837703"	"l'Alcora"	"l'Alcora"	"Q1635385"	"ca:L'Alcora"	"town"	"7"	


### PR DESCRIPTION
Xixona no reuneix cap condició per a ser `place=town` segons les directives disposades: [Núcleos_de_población](https://wiki.openstreetmap.org/wiki/ES:Directrices_de_etiquetado_espa%C3%B1olas#N%C3%BAcleos_de_poblaci%C3%B3n) y [town](https://wiki.openstreetmap.org/wiki/ES:Directrices_de_etiquetado_espa%C3%B1olas/town) 

- La seva població és inferior a 10.000 hab.
- No és cap capital comarcal
- No és cap capital judicial